### PR TITLE
feat: setup and send unique session ID with each request + log

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -21,6 +21,7 @@ import {ModelSelect} from './ModelSelect';
 import {SystemPrompt} from './SystemPrompt';
 import {TemperatureSlider} from './Temperature';
 import {MemoizedChatMessage} from './MemoizedChatMessage';
+import { useSessionId } from '@/hooks/useSessionId';
 
 interface Props {
   stopConversationRef: MutableRefObject<boolean>;
@@ -45,6 +46,8 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
     handleUpdateConversation,
     dispatch: homeDispatch,
   } = useContext(HomeContext);
+
+  const {getSessionId} = useSessionId()
 
   const [currentMessage, setCurrentMessage] = useState<Message>();
   const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true);
@@ -108,6 +111,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'Session-Id': getSessionId()
           },
           signal: controller.signal,
           body,

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -32,7 +32,7 @@ export const useFetch = () => {
           ? {}
           : { 'Content-type': 'application/json' }
         ),
-        ...{'Session-ID': getSessionId()}
+        ...{'Session-Id': getSessionId()}
     };
 
     return fetch(requestUrl, { ...requestBody, headers, signal })

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -1,3 +1,5 @@
+import { useSessionId } from "./useSessionId";
+
 export type RequestModel = {
   params?: object;
   headers?: object;
@@ -15,6 +17,7 @@ export const useFetch = () => {
     signal?: AbortSignal,
   ) => {
     const requestUrl = request?.params ? `${url}${request.params}` : url;
+    const {getSessionId} = useSessionId()
 
     const requestBody = request?.body
       ? request.body instanceof FormData
@@ -27,7 +30,7 @@ export const useFetch = () => {
         ? request.headers
         : request?.body && request.body instanceof FormData
         ? {}
-        : { 'Content-type': 'application/json' }),
+        : { 'Content-type': 'application/json' }, {'Session-ID': getSessionId()}),
     };
 
     return fetch(requestUrl, { ...requestBody, headers, signal })

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -27,10 +27,12 @@ export const useFetch = () => {
 
     const headers = {
       ...(request?.headers
-        ? request.headers
-        : request?.body && request.body instanceof FormData
-        ? {}
-        : { 'Content-type': 'application/json' }, {'Session-ID': getSessionId()}),
+          ? request.headers
+          : request?.body && request.body instanceof FormData
+          ? {}
+          : { 'Content-type': 'application/json' }
+        ),
+        ...{'Session-ID': getSessionId()}
     };
 
     return fetch(requestUrl, { ...requestBody, headers, signal })

--- a/hooks/useSessionId.ts
+++ b/hooks/useSessionId.ts
@@ -1,0 +1,5 @@
+import { getSessionId} from '../services/sessionId'
+
+export const useSessionId = () => {
+    return {getSessionId}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "rehype-mathjax": "^4.0.2",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@mozilla/readability": "^0.4.4",
@@ -8393,9 +8393,13 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14710,9 +14714,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rehype-mathjax": "^4.0.2",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@mozilla/readability": "^0.4.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,20 +6,11 @@ import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 
 import '@/styles/globals.css';
-import { useSessionId } from '@/hooks/useSessionId';
-import { useEffect } from 'react';
-import { log } from 'console';
 
 const inter = Inter({ subsets: ['latin'] });
 
 function App({ Component, pageProps }: AppProps<{}>) {
   const queryClient = new QueryClient();
-  const {getSessionId} = useSessionId()
-
-  useEffect( () => {
-    console.log("Session ID")
-    console.log(getSessionId())
-  })
 
   return (
     <div className={inter.className}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,11 +6,20 @@ import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 
 import '@/styles/globals.css';
+import { useSessionId } from '@/hooks/useSessionId';
+import { useEffect } from 'react';
+import { log } from 'console';
 
 const inter = Inter({ subsets: ['latin'] });
 
 function App({ Component, pageProps }: AppProps<{}>) {
   const queryClient = new QueryClient();
+  const {getSessionId} = useSessionId()
+
+  useEffect( () => {
+    console.log("Session ID")
+    console.log(getSessionId())
+  })
 
   return (
     <div className={inter.className}>

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -50,21 +50,22 @@ const handler = async (req: Request): Promise<Response> => {
         }
 
         //log request headers
-        const allowed = ['cf-access-authenticated-user-email', 'cf-ipcountry', 'cf-connecting-ip', 'x-amzn-trace-id', 'user-agent', 'host', 'x-forwarded-port', 'x-forwarded-proto', 'x-forwarded-for'];
-        const all_headers = Object.fromEntries(req.headers);
-        const filtered_headers = Object.keys(all_headers)
+        const allowed = ['cf-access-authenticated-user-email', 'cf-ipcountry', 'cf-connecting-ip', 'x-amzn-trace-id', 'user-agent', 'host', 'x-forwarded-port', 'x-forwarded-proto', 'x-forwarded-for', 'session-id'];
+
+        const allHeaders = Object.keys(Object.fromEntries(req.headers))
           .filter(key => allowed.includes(key))
           .reduce((obj: { [index: string]: any }, key) => {
-            obj[key] = all_headers[key];
+            obj[key] = (Object.fromEntries(req.headers))[key];
             return obj;
           }, {});
         const messageToLog = {
           messages: messages,
           timestamp: new Date().toISOString(),
-          headers: filtered_headers,
-          session_id: "session_id", // TODO: add session id
+          headers: allHeaders,
+          session_id: allHeaders['session-id'], 
         };
-        console.log(` CHAT MESSAGE LOG: ${JSON.stringify(messageToLog)}`)
+        console.log(`CHAT MESSAGE LOG: \n`)
+        console.log(messageToLog)
 
         encoding.free();
 

--- a/services/sessionId.ts
+++ b/services/sessionId.ts
@@ -1,0 +1,15 @@
+import { v4 as uuidv4 } from 'uuid';
+
+
+const setSessionID = () => {
+    localStorage?.setItem('sessionId', uuidv4())
+}
+
+
+export const getSessionId = () => {
+    if(!localStorage?.getItem('sessionId')) {
+        setSessionID()
+    }
+
+    return localStorage?.getItem('sessionId')
+}

--- a/services/sessionId.ts
+++ b/services/sessionId.ts
@@ -11,5 +11,5 @@ export const getSessionId = () => {
         setSessionID()
     }
 
-    return localStorage?.getItem('sessionId')
+    return localStorage?.getItem('sessionId') ?? ''
 }


### PR DESCRIPTION
# Summary

A unique session ID is sent to the backend with each request in the headers
Header key `Session-ID`

This unique session ID is generated once user opens the app for the first time, and persists across browser reloads/close.
Session ID is the same for all chat conversations

Cases in which the session ID will be reset:

- if user is in private/incognito browsing mode
- if user changes the browser
- If user changes the device
- if user clears local storage


# Screenshots

## Client headers 

<img width="780" alt="image" src="https://github.com/pierrelandry/chatbot-ui/assets/518974/9b3eba9a-ab11-49b3-863e-e1eea00ed7ae">

## Server log

![image](https://github.com/pierrelandry/chatbot-ui/assets/518974/b964dc70-3078-4414-9edd-940d04e94f04)


